### PR TITLE
Add dhcp support to pihole

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -37,7 +37,12 @@ default_variables: {
     "pihole_ipv6":    { "optional": yes },                        # pihole ipv6 address from same network as your server ip
     "pihole_whitelist_domains": { "default": [ "www.googleadservices.com", "analytics.google.com", "clickserve.dartsearch.net", "ad.doubleclick.net" ] }, # domains are needed to use google search results
     "pihole_addlist_urls": { "default": [ "https://raw.githubusercontent.com/StevenBlack/hosts/master/hosts", "https://raw.githubusercontent.com/StevenBlack/hosts/master/alternates/fakenews-only/hosts", "https://raw.githubusercontent.com/StevenBlack/hosts/master/alternates/gambling-only/hosts" ] },
-
+    "pihole_dhcp_active": { "optional": yes },
+    "pihole_default_domain": {"default": "lan", "optional": "{{pihole_dhcp_active is not defined}}"},
+    "pihole_dhcp_range_start": { "default": "{{default_server_subnet}}.151", "optional": "{{pihole_dhcp_active is not defined}}"},
+    "pihole_dhcp_range_end": { "default": "{{default_server_subnet}}.200", "optional": "{{pihole_dhcp_active is not defined}}"},
+    "pihole_dns_overrides": {"default": [], "optional": "{{pihole_dhcp_active is not defined}}"},
+    "pihole_dhcp_reservations": {"default": [], "optional": "{{pihole_dhcp_active is not defined}}"},
 
     "dlna_ip":        { "optional": yes },                        # dlna ip address from same network as your server ip
     "dlna_ipv6":      { "optional": yes },                        # dlna ipv6 address from same network as your server ip

--- a/config/demo/env.yml
+++ b/config/demo/env.yml
@@ -17,6 +17,7 @@ staging_ip:                       "192.168.56.50"
 #intern_networks:                 [ "{{default_server_network}}", "fde7:1250:3eaf:10::1/60","fe80::/10"]
 
 pihole_ip:                        "{{default_server_subnet}}.250"
+pihole_dhcp_active:               "false"
 dlna_ip:                          "{{default_server_subnet}}.251"
 
 # used in main role 'apache' and can be an empty array []
@@ -136,3 +137,10 @@ wall_mounted_tablet_ip:           "{{default_server_subnet}}.40"    # {{authenti
 alexa_device_ids: [
     { location: "lFF_Testroom", item: "pFF_Testroom_Alexa", type: "echo", serial: "<SERIAL_NUMBER>", id: "<UID>" }
 ]
+
+pihole_dns_overrides:
+  - {ip: {{default_server_subnet}}.73, custom_dns: "tv.other.domain.com"}
+
+pihole_dhcp_reservations:
+  - { mac: 12:34:56:78:90:11, ip: {{default_server_subnet}}.73, hostname: tv-livingroom, custom_dns: ["smarttv"]}
+

--- a/roles/pihole/tasks/lists.yml
+++ b/roles/pihole/tasks/lists.yml
@@ -1,3 +1,10 @@
+- name: "Wait until pihole service is running"
+  ansible.builtin.service_facts:
+  register: temp__service_facts
+  until: temp__service_facts.ansible_facts.services['pihole.service'].state == 'running'
+  retries: 20
+  delay: 2
+  
 - name: add whitelist domains
   shell: "docker exec pihole sh -c \"pihole {{ '--white-wild ' + item[2:] if item.startswith('*.') else '-w ' + item }}\" && sleep 1"
   register: whitelist_result

--- a/roles/pihole/tasks/main.yml
+++ b/roles/pihole/tasks/main.yml
@@ -2,18 +2,86 @@
   set_fact:
     pihole_version: '2023.10.0'
   tags: [ 'update_notifier_config' ]
-  
+
 - name: prepare needed folder
   file:
     path: '{{item}}'
     state: directory
     owner: "999"
-    group: "999"
+    group: "1000"
     mode: 0770
   with_items:
     - "{{ global_etc }}pihole"
     - "{{ global_etc }}pihole/dnsmasq.d/"
-    
+
+- name: basic preflight duplicate checks
+  block:
+# source: https://www.reddit.com/r/ansible/comments/b5tzp1/ansible_get_list_of_subelements_and_assert_for/
+    - name: create data structure to check via assertion
+      set_fact:
+        dupe_check: |
+          {
+            'reservation_count_total': {{ pihole_dhcp_reservations | length }},
+            'reservation_mac_unique': {{ (pihole_dhcp_reservations | selectattr('mac', 'defined') | map(attribute='mac') | list) | unique | length }},
+            'reservation_ip_unique': {{ (pihole_dhcp_reservations | selectattr('ip', 'defined') | map(attribute='ip') | list) | unique | length }},
+            'reservation_hostname_unique': {{ (pihole_dhcp_reservations | selectattr('hostname', 'defined') | map(attribute='hostname') | list) | unique | length }}
+          }
+
+    - name: prints counts for basic duplicate checks
+      debug:
+        var: dupe_check
+
+    - name: assert no duplicates
+      assert:
+        that:
+        - dupe_check.reservation_count_total == dupe_check.reservation_mac_unique
+        - dupe_check.reservation_count_total == dupe_check.reservation_ip_unique
+        - dupe_check.reservation_count_total == dupe_check.reservation_hostname_unique
+  
+  rescue:
+    - name: dupe check
+      debug:
+        msg: "Duplicate entry: {{ item | duplicates }}"
+      loop:
+        - "{{ pihole_dhcp_reservations | selectattr('mac', 'defined') | map(attribute='mac') }}"
+        - "{{ pihole_dhcp_reservations | selectattr('ip', 'defined') | map(attribute='ip') }}"
+        - "{{ pihole_dhcp_reservations | selectattr('hostname', 'defined') | map(attribute='hostname') }}"
+
+    - name: Fail when errors
+      ansible.builtin.fail:
+        msg: 'Duplicate MAC, IP or hostname found. Go to fail!'
+  when: pihole_dhcp_active is defined and pihole_dhcp_active | bool
+
+- name: generate custom.list (local DNS records)
+  template:
+    src: templates/etc/pihole/custom.list
+    dest: "{{global_etc}}pihole/custom.list"
+    owner: "999"
+    group: "1000"
+  notify: restart pihole
+  when: pihole_dhcp_active is defined and pihole_dhcp_active | bool
+
+- name: write static dhcp file
+  template:
+    src: templates/etc/pihole/dnsmasq.d/04-pihole-static-dhcp.conf
+    dest: "{{global_etc}}pihole/dnsmasq.d/04-pihole-static-dhcp.conf"
+    owner: "999"
+    group: "1000"
+  register: dhcp_changed
+  when: pihole_dhcp_active is defined and pihole_dhcp_active | bool
+  
+- name: revoke existing leases if dhcpd file changed
+  file:
+    path: "{{global_etc}}pihole/dhcp.leases"
+    state: absent
+  when: pihole_dhcp_active is defined  and pihole_dhcp_active | bool and dhcp_changed.changed
+
+- name: revoke existing leases if dhcpd file changed
+  file:
+    path: "{{global_etc}}pihole/dhcp.leases"
+    state: touch
+  when: pihole_dhcp_active is defined  and pihole_dhcp_active | bool and dhcp_changed.changed
+
 - name: check started docker
   systemd:
     name: docker
@@ -30,19 +98,39 @@
         {% endif %}
       }
 
+- name: prepare pihole environment variables
+  set_fact:
+    pihole_env: |
+      {
+        "TZ": "{{timezone}}",
+        "WEBPASSWORD": "{{vault_pihole_password}}",
+        "DNS1": "127.0.0.11",
+        "DNS2": "no"
+        {% if pihole_dhcp_active is defined and pihole_dhcp_active | bool%}
+            , "DNS_BOGUS_PRIV": "true"
+            , "DNS_FQDN_REQUIRED": "true"
+            , "REV_SERVER": "false"
+            , "REV_SERVER_DOMAIN": "{{pihole_default_domain}}"
+            , "REV_SERVER_TARGET": "{{default_server_gateway}}"
+            , "REV_SERVER_CIDR": "{{host_server_network}}"
+            , "DHCP_ACTIVE": "{{pihole_dhcp_active}}"
+            , "DHCP_START": "{{pihole_dhcp_range_start}}"
+            , "DHCP_END": "{{pihole_dhcp_range_end}}"
+            , "DHCP_ROUTER": "{{default_server_gateway}}"
+            , "DHCP_LEASETIME": "24"
+            , "PIHOLE_DOMAIN": "{{pihole_default_domain}}"
+        {% endif %}
+      }
+
 - name: create docker container
   docker_container:
     name: pihole
     image: "pihole/pihole:{{pihole_version}}"
     state: present
 #    recreate: true
-    env:
-      TZ: "{{timezone}}"
-      WEBPASSWORD: "{{vault_pihole_password}}"
-      DNS1: "127.0.0.11"
-      DNS2: "no"
-    #capabilities:
-    #  - NET_ADMIN
+    env: "{{pihole_env}}"
+    capabilities:
+      - net_admin
     log_driver: journald
     log_options:
       tag: pihole

--- a/roles/pihole/templates/etc/pihole/custom.list
+++ b/roles/pihole/templates/etc/pihole/custom.list
@@ -1,0 +1,13 @@
+# {{ansible_managed}}
+{% for override in pihole_dns_overrides %}
+{{override.ip}} {{override.custom_dns}}
+{% endfor %}
+{% for client in pihole_dhcp_reservations %}
+{{client.ip}} {{client.hostname}}
+{{client.ip}} {{client.hostname}}.{{pihole_default_domain}}
+{% if client.custom_dns is defined %}
+{% for item in client.custom_dns %}
+{{client.ip}} {{item}}.{{pihole_default_domain}}
+{% endfor %}
+{% endif %}
+{% endfor %}

--- a/roles/pihole/templates/etc/pihole/dnsmasq.d/04-pihole-static-dhcp.conf
+++ b/roles/pihole/templates/etc/pihole/dnsmasq.d/04-pihole-static-dhcp.conf
@@ -1,0 +1,4 @@
+# {{ansible_managed}}
+{% for client in pihole_dhcp_reservations %}
+dhcp-host={{client.mac}},{{client.ip}},{{client.hostname}}
+{% endfor %}


### PR DESCRIPTION
In my environment I configured pihole to be the DHCP too (and configure DNS too). 

This feature can be activated via pihole_dhcp_active in env.yml. By default DHCP is not active and functionality should be as before (except enabling net_admin capabilities into container).

This PR fixes a defect when the tasks from list.yml are executed while the pihole service is starting (doesn't happen if you run other roles/tasks between pihole main.yml and pihole list,yml that give time to service to start.). 