### PR TITLE
openwrt public key authentication

### DIFF
--- a/roles/openwrt/tasks/main.yml
+++ b/roles/openwrt/tasks/main.yml
@@ -18,7 +18,7 @@
       {
         {% for device in openwrt_devices %}
           '{{device.host}}': {
-             'host': '{{device.host}}', 'name': '{{device.name}}', 'is_ap': {{'1' if 'ap' in device.config.openwrt.deployment_roles else '0'}}, 'index': {{loop.index - 1}},
+             'host': '{{device.host}}', 'name': '{{device.name}}', 'sshauth': '{{device.config.openwrt.sshauth | default("password")}}', 'is_ap': {{'1' if 'ap' in device.config.openwrt.deployment_roles else '0'}}, 'index': {{loop.index - 1}},
              'features': [
                {% for feature in default_features %}
                  { 'name': '{{feature}}', 'cfg': 'service_config_{{feature}}'},
@@ -150,6 +150,7 @@
       ]
     hostname: "{{item.name | lower}}"
     is_ap: "{{ item.is_ap }}"
+    sshauth: "{{ item.sshauth }}"
   template:
     src: "templates/deploy.env"
     dest: "{{global_etc}}openwrt/ap/{{item.host}}.env"

--- a/roles/openwrt/templates/deploy.env
+++ b/roles/openwrt/templates/deploy.env
@@ -1,3 +1,4 @@
+SSHAUTH="{{sshauth}}"
 TIMEZONE="{{timezone}}" 
 HOSTNAME="{{hostname}}"
 IS_AP={{is_ap}}


### PR DESCRIPTION
Implement public key  authentication to OpenWrt. If public key authentication is enabled server, then the [~/.ssh/config](https://linux.die.net/man/5/ssh_config) on the client side most contain something like:
```
host terminus
 Hostname 192.168.120.1
 IdentityFile ~/.ssh/sshkey_ed25519
 Port 22
 User root
``` 

Additional fixes with this PR:
 * fix hardcoding of uci configuration for system
 * fix split of services (issue only when more services configured on deployment_features)